### PR TITLE
Fix minor backend typos

### DIFF
--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -75,9 +75,9 @@ const loginUser = async (req, res) => {
 const getProfile = async (req, res) => {
   try {
     const { userId } = req.body;
-    const useData = await userModel.findById(userId).select("-password");
+    const userData = await userModel.findById(userId).select("-password");
 
-    res.json({ success: true, user: useData });
+    res.json({ success: true, user: userData });
   } catch (error) {
     console.log(error);
     res.json({ success: false, message: error.message });

--- a/backend/middlewares/authAdmin.js
+++ b/backend/middlewares/authAdmin.js
@@ -22,4 +22,4 @@ const authAdmin = async (req, res, next) => {
     }
 }
 
-export default authAdmin
+export default authAdmin;


### PR DESCRIPTION
## Summary
- fix typo in getProfile response
- add semicolon to admin auth middleware

## Testing
- `npm test` in `backend`
- `npm test` in `admin` (fails: missing script)
- `npm test` in `clientside` (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_687e45d12330832e86f03eef75a714f9